### PR TITLE
feat: persist tiles and show purchased list

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ This repository contains a mobile-friendly web application for evaluating Patchw
 - Slider to set the current game age
 - Draw shapes on a 5×5 grid and assign buttons, cost, and time penalty
 - Calculates points per cost, points per cost per area, and net points
-- Pieces disappear once purchased
+- Persistent piece library with edit and delete options
+- Purchased tiles move to a separate page and reappear after starting a new game
 - Server uses Express with Helmet and Pino for security and logging
 - Configurable port and production mode
 

--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
 <body>
   <header>
     <h1>Patchwork Tile Helper</h1>
-    <p class="instructions">Select the current age, then add or buy tiles. Tap cells to draw shapes.</p>
+    <p class="instructions">Select the current age, then add or buy tiles. Tap cells to draw shapes. Use "New Game" to reset purchases.</p>
   </header>
   <section class="age-control">
     <label for="age">Current Age: <span id="ageDisplay">0</span></label>
@@ -32,6 +32,8 @@
   </section>
   <section class="piece-actions">
     <button id="addPieceBtn">Add Piece</button>
+    <button id="newGameBtn">New Game</button>
+    <button id="viewPurchasedBtn">View Purchased Tiles</button>
   </section>
   <section>
     <table id="piecesTable">
@@ -63,6 +65,6 @@
       <button id="cancelPiece">Cancel</button>
     </div>
   </section>
-  <script src="app.js"></script>
+  <script src="patchwork_client.js"></script>
 </body>
 </html>

--- a/public/purchased.html
+++ b/public/purchased.html
@@ -1,0 +1,44 @@
+<!--
+  Patchwork Purchased Tiles Page
+  ------------------------------
+  Mini README:
+  This HTML page lists tiles that have been purchased in the current game.
+  It allows players to review their buys and optionally return a tile to the
+  available pool.
+
+  Structure:
+  - Instructions header with navigation back to the game
+  - Table displaying purchased tiles
+  - Script handling rendering and return actions
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Purchased Tiles</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>Purchased Tiles</h1>
+    <p class="instructions">These tiles have been bought this game. Use "Return" to undo a purchase.</p>
+    <button id="backBtn">Back to Game</button>
+  </header>
+  <section>
+    <table id="purchasedTable">
+      <thead>
+        <tr>
+          <th>Shape</th>
+          <th>Buttons</th>
+          <th>Cost</th>
+          <th>Time</th>
+          <th>Action</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </section>
+  <script src="purchased_client.js"></script>
+</body>
+</html>

--- a/public/purchased_client.js
+++ b/public/purchased_client.js
@@ -1,0 +1,83 @@
+/*
+ Purchased Tiles Client Script
+ -----------------------------
+ Mini README:
+ This script renders the list of tiles purchased during the current game and
+ allows players to return a tile to the available pool if selected by mistake.
+
+ Structure:
+ - Load purchased tiles from localStorage
+ - Render table with shapes and a return button
+ - Navigation back to the main game interface
+*/
+
+let purchasedPieces = JSON.parse(localStorage.getItem('purchasedPieces') || '[]');
+
+const purchasedTableBody = document.querySelector('#purchasedTable tbody');
+const backBtn = document.getElementById('backBtn');
+
+function renderShape(shape) {
+  const container = document.createElement('div');
+  container.classList.add('grid');
+  container.style.gridTemplateColumns = 'repeat(5, 12px)';
+  container.style.gridTemplateRows = 'repeat(5, 12px)';
+  for (let i = 0; i < 25; i++) {
+    const cell = document.createElement('div');
+    const x = i % 5;
+    const y = Math.floor(i / 5);
+    if (shape.some(p => p.x === x && p.y === y)) {
+      cell.classList.add('active');
+    }
+    cell.style.width = '12px';
+    cell.style.height = '12px';
+    container.appendChild(cell);
+  }
+  return container;
+}
+
+function savePurchased() {
+  localStorage.setItem('purchasedPieces', JSON.stringify(purchasedPieces));
+}
+
+function refreshTable() {
+  purchasedTableBody.innerHTML = '';
+  purchasedPieces.forEach(piece => {
+    const tr = document.createElement('tr');
+
+    const shapeTd = document.createElement('td');
+    shapeTd.appendChild(renderShape(piece.shape));
+    tr.appendChild(shapeTd);
+
+    const buttonsTd = document.createElement('td');
+    buttonsTd.textContent = piece.buttons;
+    tr.appendChild(buttonsTd);
+
+    const costTd = document.createElement('td');
+    costTd.textContent = piece.cost;
+    tr.appendChild(costTd);
+
+    const timeTd = document.createElement('td');
+    timeTd.textContent = piece.time;
+    tr.appendChild(timeTd);
+
+    const actionTd = document.createElement('td');
+    const returnBtn = document.createElement('button');
+    returnBtn.textContent = 'Return';
+    returnBtn.addEventListener('click', () => {
+      purchasedPieces = purchasedPieces.filter(p => p.id !== piece.id);
+      savePurchased();
+      refreshTable();
+    });
+    actionTd.appendChild(returnBtn);
+    tr.appendChild(actionTd);
+
+    purchasedTableBody.appendChild(tr);
+  });
+}
+
+backBtn.addEventListener('click', () => {
+  window.location.href = 'index.html';
+});
+
+refreshTable();
+


### PR DESCRIPTION
## Summary
- maintain a persistent tile library with edit/delete controls
- move bought tiles to a purchased list and provide a page to review or return them
- reset purchases with a New Game button

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f7de2172c8328a58c8ad39f1d07e7