### PR TITLE
fix: allow patchwork server host and port configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains a mobile-friendly web application for evaluating Patchw
 - Persistent piece library with edit and delete options
 - Purchased tiles move to a separate page and reappear after starting a new game
 - Server uses Express with Helmet and Pino for security and logging
-- Configurable port and production mode
+- Configurable host/port and production mode
 
 ## Setup
 ### Linux / Raspberry Pi
@@ -27,14 +27,14 @@ powershell -ExecutionPolicy Bypass -File scripts/setup_patchwork_env.ps1
 ```
 
 ## Usage
-Run the server on the desired port:
+Run the server on the desired host and port:
 ```bash
 # Development
-npm run dev -- --port=4000
+npm run dev -- --port 4000 --host 0.0.0.0
 # Production
-NODE_ENV=production npm run start -- --port=8080
+NODE_ENV=production npm run start -- --port 8080 --host 0.0.0.0
 ```
-Then open `http://localhost:PORT` in a browser.
+Then open `http://HOST:PORT` in a browser from any device on the network.
 
 ## Debugging
 - Server logs are written to stdout using Pino.

--- a/patchwork_server.js
+++ b/patchwork_server.js
@@ -3,17 +3,17 @@
  * -----------------
  * Mini README:
  * This Node.js script starts an Express server that serves the Patchwork tile helper
- * web application. It supports configurable ports and a production mode.
+ * web application. It supports configurable host/port and a production mode.
  *
  * Structure:
  * - Loads environment variables and command line arguments for configuration.
  * - Sets up Express with Helmet for basic security headers and Pino for logging.
  * - Serves static files from the "public" directory.
- * - Starts the HTTP server on the requested port.
+ * - Starts the HTTP server on the requested host and port.
  *
  * Usage:
- *   node patchwork_server.js --port=4000
- *   PORT=4000 node patchwork_server.js
+ *   node patchwork_server.js --port=4000 --host=0.0.0.0
+ *   PORT=4000 HOST=0.0.0.0 node patchwork_server.js
  *   NODE_ENV=production node patchwork_server.js
  */
 
@@ -28,14 +28,28 @@ const logger = pino({
   level: process.env.NODE_ENV === 'production' ? 'info' : 'debug'
 });
 
-// Parse CLI arguments for --port
-let port = process.env.PORT || 3000;
-for (const arg of process.argv.slice(2)) {
-  if (arg.startsWith('--port=')) {
+// Parse CLI arguments for --port and --host
+let port = parseInt(process.env.PORT, 10) || 3000;
+let host = process.env.HOST || '0.0.0.0';
+const args = process.argv.slice(2);
+for (let i = 0; i < args.length; i += 1) {
+  const arg = args[i];
+  if (arg === '--port' && args[i + 1]) {
+    const value = parseInt(args[i + 1], 10);
+    if (!Number.isNaN(value)) {
+      port = value;
+    }
+    i += 1;
+  } else if (arg.startsWith('--port=')) {
     const value = parseInt(arg.split('=')[1], 10);
     if (!Number.isNaN(value)) {
       port = value;
     }
+  } else if (arg === '--host' && args[i + 1]) {
+    host = args[i + 1];
+    i += 1;
+  } else if (arg.startsWith('--host=')) {
+    host = arg.split('=')[1];
   }
 }
 
@@ -49,6 +63,6 @@ app.get('/health', (req, res) => {
   res.json({ status: 'ok' });
 });
 
-app.listen(port, () => {
-  logger.info(`Patchwork helper server running on port ${port}`);
+app.listen(port, host, () => {
+  logger.info(`Patchwork helper server running at http://${host}:${port}`);
 });


### PR DESCRIPTION
## Summary
- add support for `--port` and `--host` switches with sensible defaults
- document network-friendly host/port usage

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f8145b3208328905aad599ee54321