### PR TITLE
feat: allow color selection for pieces

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains a mobile-friendly web application for evaluating Patchw
 - Responsive interface designed for phones
 - Slider to set the current game age
 - Draw shapes on a 5×5 grid and assign buttons, cost, and time penalty
+- Choose a color for each piece
 - Calculates points per cost, points per cost per area, and net points
 - Persistent piece library with edit and delete options
 - Purchased tiles move to a separate page and reappear after starting a new game

--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
 <body>
   <header>
     <h1>Patchwork Tile Helper</h1>
-    <p class="instructions">Select the current age, then add or buy tiles. Tap cells to draw shapes. Use "New Game" to reset purchases.</p>
+    <p class="instructions">Select the current age, then add or buy tiles. Tap cells to draw shapes and choose a color. Use "New Game" to reset purchases.</p>
   </header>
   <section class="age-control">
     <label for="age">Current Age: <span id="ageDisplay">0</span></label>
@@ -59,6 +59,7 @@
       <label>Buttons: <input type="number" id="buttonsInput" min="0" value="0" /></label>
       <label>Cost: <input type="number" id="costInput" min="0" value="0" /></label>
       <label>Time Penalty: <input type="number" id="timeInput" min="0" value="0" /></label>
+      <label>Color: <input type="color" id="colorInput" value="#4caf50" /></label>
     </div>
     <div class="form-actions">
       <button id="savePiece">Save</button>

--- a/public/patchwork_client.js
+++ b/public/patchwork_client.js
@@ -4,7 +4,7 @@
  Mini README:
  This browser script powers the main Patchwork helper interface. It manages
  a persistent library of tiles, handles purchases during a game, and allows
- pieces to be created, edited, or deleted.
+ pieces to be created, colored, edited, or deleted.
 
  Structure:
  - State management for library, available, and purchased tiles
@@ -17,6 +17,9 @@ let currentAge = 0;
 let nextId = parseInt(localStorage.getItem('nextId'), 10) || 1;
 let pieceLibrary = JSON.parse(localStorage.getItem('pieceLibrary') || '[]');
 let purchasedPieces = JSON.parse(localStorage.getItem('purchasedPieces') || '[]');
+// ensure legacy pieces get a default color
+pieceLibrary.forEach(p => { if (!p.color) p.color = '#4caf50'; });
+purchasedPieces.forEach(p => { if (!p.color) p.color = '#4caf50'; });
 let availablePieces = pieceLibrary.filter(p => !purchasedPieces.some(pp => pp.id === p.id));
 let editingPieceId = null;
 
@@ -31,6 +34,7 @@ const grid = document.getElementById('grid');
 const buttonsInput = document.getElementById('buttonsInput');
 const costInput = document.getElementById('costInput');
 const timeInput = document.getElementById('timeInput');
+const colorInput = document.getElementById('colorInput');
 const savePieceBtn = document.getElementById('savePiece');
 const cancelPieceBtn = document.getElementById('cancelPiece');
 
@@ -45,12 +49,19 @@ function savePurchased() {
 
 function createGrid() {
   grid.innerHTML = '';
+  // apply current color selection to grid cells
+  grid.style.setProperty('--active-color', colorInput.value);
   for (let i = 0; i < 25; i++) {
     const cell = document.createElement('div');
     cell.addEventListener('click', () => cell.classList.toggle('active'));
     grid.appendChild(cell);
   }
 }
+
+// preview color while drawing
+colorInput.addEventListener('input', () => {
+  grid.style.setProperty('--active-color', colorInput.value);
+});
 
 function loadShapeIntoGrid(shape) {
   createGrid();
@@ -75,11 +86,12 @@ function getGridShape() {
   return shape;
 }
 
-function renderShape(shape) {
+function renderShape(shape, color = '#4caf50') {
   const container = document.createElement('div');
   container.classList.add('grid');
   container.style.gridTemplateColumns = 'repeat(5, 12px)';
   container.style.gridTemplateRows = 'repeat(5, 12px)';
+  container.style.setProperty('--active-color', color);
   for (let i = 0; i < 25; i++) {
     const cell = document.createElement('div');
     const x = i % 5;
@@ -111,7 +123,7 @@ function refreshTable() {
     const tr = document.createElement('tr');
 
     const shapeTd = document.createElement('td');
-    shapeTd.appendChild(renderShape(piece.shape));
+    shapeTd.appendChild(renderShape(piece.shape, piece.color));
     tr.appendChild(shapeTd);
 
     const buttonsTd = document.createElement('td');
@@ -161,6 +173,7 @@ function refreshTable() {
       buttonsInput.value = piece.buttons;
       costInput.value = piece.cost;
       timeInput.value = piece.time;
+      colorInput.value = piece.color || '#4caf50';
       loadShapeIntoGrid(piece.shape);
       pieceForm.classList.remove('hidden');
     });
@@ -194,6 +207,7 @@ ageInput.addEventListener('input', () => {
 addPieceBtn.addEventListener('click', () => {
   editingPieceId = null;
   pieceForm.classList.remove('hidden');
+  colorInput.value = '#4caf50';
   createGrid();
   buttonsInput.value = 0;
   costInput.value = 0;
@@ -213,6 +227,7 @@ savePieceBtn.addEventListener('click', () => {
       piece.buttons = parseInt(buttonsInput.value, 10) || 0;
       piece.cost = parseInt(costInput.value, 10) || 0;
       piece.time = parseInt(timeInput.value, 10) || 0;
+      piece.color = colorInput.value;
     }
     const avail = availablePieces.find(p => p.id === editingPieceId);
     if (avail) Object.assign(avail, piece);
@@ -225,7 +240,8 @@ savePieceBtn.addEventListener('click', () => {
       shape,
       buttons: parseInt(buttonsInput.value, 10) || 0,
       cost: parseInt(costInput.value, 10) || 0,
-      time: parseInt(timeInput.value, 10) || 0
+      time: parseInt(timeInput.value, 10) || 0,
+      color: colorInput.value
     };
     console.debug('Adding piece', piece);
     pieceLibrary.push(piece);
@@ -255,4 +271,7 @@ viewPurchasedBtn.addEventListener('click', () => {
 // initialize
 createGrid();
 refreshTable();
+// persist any defaulted data to storage
+saveLibrary();
+savePurchased();
 

--- a/public/purchased_client.js
+++ b/public/purchased_client.js
@@ -4,6 +4,7 @@
  Mini README:
  This script renders the list of tiles purchased during the current game and
  allows players to return a tile to the available pool if selected by mistake.
+ Each piece is shown using its chosen color.
 
  Structure:
  - Load purchased tiles from localStorage
@@ -12,15 +13,18 @@
 */
 
 let purchasedPieces = JSON.parse(localStorage.getItem('purchasedPieces') || '[]');
+// assign default color to legacy pieces
+purchasedPieces.forEach(p => { if (!p.color) p.color = '#4caf50'; });
 
 const purchasedTableBody = document.querySelector('#purchasedTable tbody');
 const backBtn = document.getElementById('backBtn');
 
-function renderShape(shape) {
+function renderShape(shape, color = '#4caf50') {
   const container = document.createElement('div');
   container.classList.add('grid');
   container.style.gridTemplateColumns = 'repeat(5, 12px)';
   container.style.gridTemplateRows = 'repeat(5, 12px)';
+  container.style.setProperty('--active-color', color);
   for (let i = 0; i < 25; i++) {
     const cell = document.createElement('div');
     const x = i % 5;
@@ -45,7 +49,7 @@ function refreshTable() {
     const tr = document.createElement('tr');
 
     const shapeTd = document.createElement('td');
-    shapeTd.appendChild(renderShape(piece.shape));
+    shapeTd.appendChild(renderShape(piece.shape, piece.color));
     tr.appendChild(shapeTd);
 
     const buttonsTd = document.createElement('td');

--- a/public/styles.css
+++ b/public/styles.css
@@ -70,6 +70,8 @@ header {
   grid-template-rows: repeat(5, 30px);
   gap: 2px;
   margin-bottom: 1rem;
+  /* default active color used by grid cells */
+  --active-color: #4caf50;
 }
 
 .grid div {
@@ -80,7 +82,8 @@ header {
 }
 
 .grid div.active {
-  background: #4caf50;
+  /* use CSS variable so each grid can set its own piece color */
+  background: var(--active-color);
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- add color picker to piece editor and store color with each piece
- render piece shapes using chosen color in lists and purchased view
- use CSS variables for configurable grid cell color

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f8181cd7c8328a4b6805db74aa455