### PR TITLE
feat: enable sorting on piece tables

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,13 +4,14 @@
   Mini README:
   This HTML file renders the user interface for creating and evaluating Patchwork
   tiles. It includes controls for selecting the current age, adding new pieces,
-  and viewing their calculated values.
+  and viewing their calculated values. Columns in the pieces table can be
+  clicked to sort the available tiles.
 
   Structure:
   - Instructions header
   - Age selection slider
   - Button to open the "Add Piece" form
-  - Table listing all available pieces
+  - Table listing all available pieces with sortable columns
   - Hidden modal-like form for drawing a new piece
 -->
 <!DOCTYPE html>
@@ -24,7 +25,7 @@
 <body>
   <header>
     <h1>Patchwork Tile Helper</h1>
-    <p class="instructions">Select the current age, then add or buy tiles. Tap cells to draw shapes. Use "New Game" to reset purchases.</p>
+    <p class="instructions">Select the current age, then add or buy tiles. Tap cells to draw shapes. Tap column headers to sort pieces. Use "New Game" to reset purchases.</p>
   </header>
   <section class="age-control">
     <label for="age">Current Age: <span id="ageDisplay">0</span></label>
@@ -40,12 +41,12 @@
       <thead>
         <tr>
           <th>Shape</th>
-          <th>Buttons</th>
-          <th>Cost</th>
-          <th>Time</th>
-          <th>P/C</th>
-          <th>P/C/A</th>
-          <th>Net</th>
+          <th data-sort="buttons" class="sortable">Buttons</th>
+          <th data-sort="cost" class="sortable">Cost</th>
+          <th data-sort="time" class="sortable">Time</th>
+          <th data-sort="pointsPerCost" class="sortable">P/C</th>
+          <th data-sort="pointsPerCostPerArea" class="sortable">P/C/A</th>
+          <th data-sort="netPoints" class="sortable">Net</th>
           <th>Action</th>
         </tr>
       </thead>

--- a/public/purchased.html
+++ b/public/purchased.html
@@ -4,11 +4,11 @@
   Mini README:
   This HTML page lists tiles that have been purchased in the current game.
   It allows players to review their buys and optionally return a tile to the
-  available pool.
+  available pool. Columns in the table can be clicked to sort the purchases.
 
   Structure:
   - Instructions header with navigation back to the game
-  - Table displaying purchased tiles
+  - Table displaying purchased tiles with sortable columns
   - Script handling rendering and return actions
 -->
 <!DOCTYPE html>
@@ -22,7 +22,7 @@
 <body>
   <header>
     <h1>Purchased Tiles</h1>
-    <p class="instructions">These tiles have been bought this game. Use "Return" to undo a purchase.</p>
+    <p class="instructions">These tiles have been bought this game. Tap column headers to sort. Use "Return" to undo a purchase.</p>
     <button id="backBtn">Back to Game</button>
   </header>
   <section>
@@ -30,9 +30,9 @@
       <thead>
         <tr>
           <th>Shape</th>
-          <th>Buttons</th>
-          <th>Cost</th>
-          <th>Time</th>
+          <th data-sort="buttons" class="sortable">Buttons</th>
+          <th data-sort="cost" class="sortable">Cost</th>
+          <th data-sort="time" class="sortable">Time</th>
           <th>Action</th>
         </tr>
       </thead>

--- a/public/purchased_client.js
+++ b/public/purchased_client.js
@@ -4,17 +4,36 @@
  Mini README:
  This script renders the list of tiles purchased during the current game and
  allows players to return a tile to the available pool if selected by mistake.
+ Columns in the table can be clicked to sort the purchases.
 
  Structure:
  - Load purchased tiles from localStorage
- - Render table with shapes and a return button
+ - Render table with shapes, sortable headers, and a return button
  - Navigation back to the main game interface
 */
 
 let purchasedPieces = JSON.parse(localStorage.getItem('purchasedPieces') || '[]');
 
 const purchasedTableBody = document.querySelector('#purchasedTable tbody');
+const purchasedTableHeaders = document.querySelectorAll('#purchasedTable th');
 const backBtn = document.getElementById('backBtn');
+
+const sortState = { key: null, asc: true };
+
+purchasedTableHeaders.forEach(th => {
+  const key = th.dataset.sort;
+  if (!key) return;
+  th.addEventListener('click', () => {
+    if (sortState.key === key) {
+      sortState.asc = !sortState.asc;
+    } else {
+      sortState.key = key;
+      sortState.asc = true;
+    }
+    console.debug('Sorting purchases by', key, sortState.asc ? 'asc' : 'desc');
+    refreshTable();
+  });
+});
 
 function renderShape(shape) {
   const container = document.createElement('div');
@@ -39,8 +58,37 @@ function savePurchased() {
   localStorage.setItem('purchasedPieces', JSON.stringify(purchasedPieces));
 }
 
+function getSortValue(piece, key) {
+  switch (key) {
+    case 'buttons':
+      return piece.buttons;
+    case 'cost':
+      return piece.cost;
+    case 'time':
+      return piece.time;
+    default:
+      return 0;
+  }
+}
+
+function sortPurchasedPieces() {
+  if (!sortState.key) return;
+  purchasedPieces.sort((a, b) => {
+    const aVal = getSortValue(a, sortState.key);
+    const bVal = getSortValue(b, sortState.key);
+    return sortState.asc ? aVal - bVal : bVal - aVal;
+  });
+}
+
 function refreshTable() {
+  sortPurchasedPieces();
   purchasedTableBody.innerHTML = '';
+  purchasedTableHeaders.forEach(th => {
+    th.classList.remove('asc', 'desc');
+    if (th.dataset.sort === sortState.key) {
+      th.classList.add(sortState.asc ? 'asc' : 'desc');
+    }
+  });
   purchasedPieces.forEach(piece => {
     const tr = document.createElement('tr');
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -9,6 +9,7 @@
  - General layout and typography
  - Table styling for pieces list
  - Grid styling for drawing new pieces
+ - Sortable header indicators
  - Responsive tweaks
 */
 
@@ -51,6 +52,19 @@ header {
   border: 1px solid #ccc;
   padding: 0.5rem;
   text-align: center;
+}
+
+th.sortable {
+  cursor: pointer;
+  user-select: none;
+}
+
+th.sortable.asc::after {
+  content: ' \25B2';
+}
+
+th.sortable.desc::after {
+  content: ' \25BC';
 }
 
 #pieceForm {


### PR DESCRIPTION
## Summary
- make piece tables sortable by clicking column headers
- add visual sort indicators and user instructions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f81df32d083288a5d4b4c84ed8633