### PR TITLE
fix: correct patch value calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This repository contains a mobile-friendly web application for evaluating Patchw
 - Responsive interface designed for phones
 - Slider to set the current game age
 - Draw shapes on a 5×5 grid and assign buttons, cost, and time penalty
-- Calculates points per cost, points per cost per area, and net points
+ - Calculates points per cost, points per cost per area, and net points using
+   2 points per covered square plus button income for the remaining nine ages
 - Persistent piece library with edit and delete options
 - Purchased tiles move to a separate page and reappear after starting a new game
 - Server uses Express with Helmet and Pino for security and logging

--- a/public/patchwork_client.js
+++ b/public/patchwork_client.js
@@ -13,6 +13,7 @@
 */
 
 const TOTAL_TIME = 53; // total time spaces in Patchwork
+const INCOME_SPACES = [5, 11, 17, 23, 29, 35, 41, 47, 53]; // board spaces that grant button income
 let currentAge = 0;
 let nextId = parseInt(localStorage.getItem('nextId'), 10) || 1;
 let pieceLibrary = JSON.parse(localStorage.getItem('pieceLibrary') || '[]');
@@ -95,10 +96,17 @@ function renderShape(shape) {
 }
 
 function computeStats(piece) {
+  // Each patch square is worth two points. Buttons generate income at every
+  // remaining "age" (button space) on the time track after purchase. The
+  // piece's overall value is therefore:
+  //   (area * 2) + (buttons * remaining ages) - cost
   const area = piece.shape.length;
-  const pointsPerCost = piece.cost ? piece.buttons / piece.cost : piece.buttons;
-  const pointsPerCostPerArea = piece.cost && area ? piece.buttons / (piece.cost * area) : 0;
-  const netPoints = piece.buttons - piece.cost;
+  const squarePoints = area * 2;
+  const incomesRemaining = INCOME_SPACES.filter(s => s > currentAge).length;
+  const buttonPoints = piece.buttons * incomesRemaining;
+  const netPoints = squarePoints + buttonPoints - piece.cost;
+  const pointsPerCost = piece.cost ? netPoints / piece.cost : netPoints;
+  const pointsPerCostPerArea = piece.cost && area ? netPoints / (piece.cost * area) : 0;
   const remaining = TOTAL_TIME - currentAge - piece.time;
   const valid = remaining >= 0;
   return { area, pointsPerCost, pointsPerCostPerArea, netPoints, valid };


### PR DESCRIPTION
## Summary
- calculate patch value using square coverage and remaining-age button income
- document scoring formula in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f82f52ad083289857b21e68aaaa7a