### PR TITLE
fix: honor npm port and host switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,11 @@ powershell -ExecutionPolicy Bypass -File scripts/setup_patchwork_env.ps1
 Run the server on the desired host and port:
 ```bash
 # Development
-npm run dev -- --port 4000 --host 0.0.0.0
+npm run dev --port 4000 --host 0.0.0.0
 # Production
-NODE_ENV=production npm run start -- --port 8080 --host 0.0.0.0
+npm start --port 8080 --host 0.0.0.0
+# Alternatively use environment variables
+PORT=5000 HOST=0.0.0.0 npm start
 ```
 Then open `http://HOST:PORT` in a browser from any device on the network.
 

--- a/patchwork_server.js
+++ b/patchwork_server.js
@@ -4,6 +4,7 @@
  * Mini README:
  * This Node.js script starts an Express server that serves the Patchwork tile helper
  * web application. It supports configurable host/port and a production mode.
+ * Command line options or NPM-style `--port` and `--host` switches can override defaults.
  *
  * Structure:
  * - Loads environment variables and command line arguments for configuration.
@@ -14,6 +15,7 @@
  * Usage:
  *   node patchwork_server.js --port=4000 --host=0.0.0.0
  *   PORT=4000 HOST=0.0.0.0 node patchwork_server.js
+ *   npm start --port 4000 --host 0.0.0.0
  *   NODE_ENV=production node patchwork_server.js
  */
 
@@ -28,9 +30,13 @@ const logger = pino({
   level: process.env.NODE_ENV === 'production' ? 'info' : 'debug'
 });
 
-// Parse CLI arguments for --port and --host
-let port = parseInt(process.env.PORT, 10) || 3000;
-let host = process.env.HOST || '0.0.0.0';
+// Resolve port/host from environment variables first. NPM passes CLI switches as
+// npm_config_* variables when invoked like `npm start --port 4000`.
+let port = parseInt(process.env.PORT || process.env.npm_config_port, 10);
+if (Number.isNaN(port)) {
+  port = 3000;
+}
+let host = process.env.HOST || process.env.npm_config_host || '0.0.0.0';
 const args = process.argv.slice(2);
 for (let i = 0; i < args.length; i += 1) {
   const arg = args[i];
@@ -50,8 +56,14 @@ for (let i = 0; i < args.length; i += 1) {
     i += 1;
   } else if (arg.startsWith('--host=')) {
     host = arg.split('=')[1];
+  } else if (/^\d+$/.test(arg)) {
+    // Support bare numeric argument from `npm start --port 4000`
+    port = parseInt(arg, 10);
   }
 }
+
+// Helpful debug log of the resolved configuration
+logger.debug(`Resolved configuration host=${host} port=${port}`);
 
 const app = express();
 app.use(helmet());


### PR DESCRIPTION
## Summary
- support npm `--port` and `--host` switches by reading npm_config_* env vars
- add debug logging for resolved host/port
- document direct `npm start --port` usage in README

## Testing
- `npm test`
- `npm run lint`
- `npm start --port 4010`

------
https://chatgpt.com/codex/tasks/task_e_689f86b859348328bd885a80351081d1