### PR TITLE
Limit age slider to paydays and compute net piece value

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains a mobile-friendly web application for evaluating Patchw
 
 ## Features
 - Responsive interface designed for phones
-- Slider to set the current game age
+- Slider to set the current payday (1–9)
 - Draw shapes on a 5×5 grid and assign buttons, cost, and time penalty
 - Choose a color for each piece
 - Calculates points per cost, points per cost per area, and net points

--- a/public/index.html
+++ b/public/index.html
@@ -3,12 +3,12 @@
   ------------------------------
   Mini README:
   This HTML file renders the user interface for creating and evaluating Patchwork
-  tiles. It includes controls for selecting the current age, adding new pieces,
+  tiles. It includes controls for selecting the current payday, adding new pieces,
   and viewing their calculated values.
 
   Structure:
   - Instructions header
-  - Age selection slider
+  - Payday selection slider
   - Button to open the "Add Piece" form
   - Table listing all available pieces with a calculated value column (sortable by headers)
   - Hidden modal-like form for drawing a new piece
@@ -24,11 +24,11 @@
 <body>
   <header>
     <h1>Patchwork Tile Helper</h1>
-    <p class="instructions">Select the current age, then add or buy tiles. Tap cells to draw shapes and choose a color. Use "New Game" to reset purchases. Tap column headers to sort pieces.</p>
+    <p class="instructions">Select the current payday, then add or buy tiles. Tap cells to draw shapes and choose a color. Use "New Game" to reset purchases. Tap column headers to sort pieces.</p>
   </header>
   <section class="age-control">
-    <label for="age">Current Age: <span id="ageDisplay">0</span></label>
-    <input type="range" id="age" min="0" max="53" value="0" />
+    <label for="age">Current Payday: <span id="ageDisplay">1</span></label>
+    <input type="range" id="age" min="1" max="9" value="1" />
   </section>
   <section class="piece-actions">
     <button id="addPieceBtn">Add Piece</button>

--- a/public/purchased_client.js
+++ b/public/purchased_client.js
@@ -13,12 +13,13 @@
  - Navigation back to the main game interface
 */
 
-const AGE_COUNT = 9; // total number of scoring ages
+const AGE_COUNT = 9; // total number of paydays/ages
 let purchasedPieces = JSON.parse(localStorage.getItem('purchasedPieces') || '[]');
 // assign defaults to legacy pieces
 purchasedPieces.forEach(p => {
   if (!p.color) p.color = '#4caf50';
-  if (p.purchaseAge === undefined) p.purchaseAge = 0;
+  // normalize legacy data to the new 1–9 age scale
+  if (p.purchaseAge === undefined || p.purchaseAge < 1) p.purchaseAge = 1;
 });
 
 const purchasedTableBody = document.querySelector('#purchasedTable tbody');


### PR DESCRIPTION
## Summary
- Restrict age control to 9 payday markers for clearer game tracking
- Compute tile value as area plus future buttons minus cost
- Normalize stored purchase ages to the new 1–9 scale
- Document new payday slider in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f8c7aa6c483289e0b9cda93c21ffc