### PR TITLE
Store purchase-time tile value

### DIFF
--- a/public/purchased.html
+++ b/public/purchased.html
@@ -3,12 +3,12 @@
   ------------------------------
   Mini README:
   This HTML page lists tiles that have been purchased in the current game.
-  It allows players to review their buys, see each tile's net value, and
-  optionally return a tile to the available pool.
+  It allows players to review their buys, see each tile's value at the time of
+  purchase, and optionally return a tile to the available pool.
 
   Structure:
   - Instructions header with navigation back to the game
-  - Table displaying purchased tiles and their values
+  - Table displaying purchased tiles and their purchase-time values
   - Script handling rendering and return actions
 -->
 <!DOCTYPE html>
@@ -22,7 +22,7 @@
 <body>
   <header>
     <h1>Purchased Tiles</h1>
-    <p class="instructions">These tiles have been bought this game. Use "Return" to undo a purchase.</p>
+    <p class="instructions">These tiles have been bought this game. Values reflect remaining paydays at purchase. Use "Return" to undo a purchase.</p>
     <button id="backBtn">Back to Game</button>
   </header>
   <section>
@@ -33,7 +33,7 @@
           <th>Buttons</th>
           <th>Cost</th>
           <th>Time</th>
-          <th>Value</th>
+          <th>Purchase Value</th>
           <th>Action</th>
         </tr>
       </thead>

--- a/public/purchased_client.js
+++ b/public/purchased_client.js
@@ -4,23 +4,27 @@
  Mini README:
  This script renders the list of tiles purchased during the current game and
  allows players to return a tile to the available pool if selected by mistake.
- Each piece is shown using its chosen color and calculated net value.
+ Each piece is shown using its chosen color and the value it had when
+ purchased, ensuring scores remain historically accurate.
 
  Structure:
  - Load purchased tiles from localStorage
- - Compute and display each tile's net value
+ - Display each tile's value at purchase time
  - Render table with shapes and a return button
  - Navigation back to the main game interface
 */
 
 const AGE_COUNT = 9; // total number of paydays/ages
 let purchasedPieces = JSON.parse(localStorage.getItem('purchasedPieces') || '[]');
-// assign defaults to legacy pieces
+// assign defaults to legacy pieces and compute missing purchase values
 purchasedPieces.forEach(p => {
   if (!p.color) p.color = '#4caf50';
   // normalize legacy data to the new 1–9 age scale
   if (p.purchaseAge === undefined || p.purchaseAge < 1) p.purchaseAge = 1;
+  if (p.purchaseValue === undefined) p.purchaseValue = computeValue(p);
 });
+// persist any computed defaults
+savePurchased();
 
 const purchasedTableBody = document.querySelector('#purchasedTable tbody');
 const backBtn = document.getElementById('backBtn');
@@ -78,7 +82,8 @@ function refreshTable() {
     tr.appendChild(timeTd);
 
     const valueTd = document.createElement('td');
-    valueTd.textContent = computeValue(piece);
+    // display stored purchase-time value to reflect scoring at buy time
+    valueTd.textContent = piece.purchaseValue ?? computeValue(piece);
     tr.appendChild(valueTd);
 
     const actionTd = document.createElement('td');


### PR DESCRIPTION
## Summary
- Store each tile's value when purchased
- Display stored purchase-time values on purchased tiles page
- Clarify purchased tiles page column and instructions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f8fb8db188328a9f8b43499c60116