### PR TITLE
Hide action column on small screens

### DIFF
--- a/public/purchased.html
+++ b/public/purchased.html
@@ -10,7 +10,7 @@
   - Instructions header with navigation back to the game
   - Optional dropdown to choose visible metric on small screens
   - Table displaying purchase-time value metrics
-  - Script handling rendering and return actions
+  - Script handling rendering and return actions (action column hidden on small screens)
 -->
 <!DOCTYPE html>
 <html lang="en">
@@ -42,7 +42,7 @@
           <th class="value">Current Value</th>
           <th class="valuePerTime">Value / Time</th>
           <th class="valuePerTimePerArea">Value / Time / Area</th>
-          <th>Action</th>
+          <th class="action">Action</th>
         </tr>
       </thead>
       <tbody></tbody>

--- a/public/purchased_client.js
+++ b/public/purchased_client.js
@@ -94,6 +94,7 @@ function refreshTable() {
     tr.appendChild(vptaTd);
 
     const actionTd = document.createElement('td');
+    actionTd.classList.add('action');
     const returnBtn = document.createElement('button');
     returnBtn.textContent = 'Return';
     returnBtn.addEventListener('click', () => {

--- a/public/styles.css
+++ b/public/styles.css
@@ -120,13 +120,18 @@ header {
     display: block;
   }
 
-  /* hide metric columns by default */
+  /* hide metric and action columns by default on narrow screens */
   #purchasedTable th.value,
   #purchasedTable th.valuePerTime,
   #purchasedTable th.valuePerTimePerArea,
   #purchasedTable td.value,
   #purchasedTable td.valuePerTime,
   #purchasedTable td.valuePerTimePerArea {
+    display: none;
+  }
+
+  #purchasedTable th.action,
+  #purchasedTable td.action {
     display: none;
   }
 


### PR DESCRIPTION
## Summary
- Mark the purchased tiles page's action column and hide it on narrow screens for cleaner responsive layout
- Update small-screen CSS rules so only the shape and selected metric are displayed

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fa3de78e08328a7f348a3d82be1a0