### PR TITLE
Add current value metrics columns to pieces table

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains a mobile-friendly web application for evaluating Patchw
 - Slider to set the current payday (1–9)
 - Draw shapes on a 5×5 grid and assign buttons, cost, and time penalty
 - Choose a color for each piece
-- Calculates points per cost, points per cost per area, and net points
+- Calculates current value, value per time penalty, and value per time penalty per area
 - Persistent piece library with edit and delete options
 - Purchased tiles move to a separate page and reappear after starting a new game
 - Purchased page displays purchase-time value and efficiency metrics with a mobile-friendly column selector

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
   - Instructions header
   - Payday selection slider
   - Button to open the "Add Piece" form
-  - Table listing all available pieces with a calculated value column (sortable by headers)
+  - Table listing all available pieces with current value metrics (sortable by headers)
   - Hidden modal-like form for drawing a new piece
 -->
 <!DOCTYPE html>
@@ -42,10 +42,10 @@
           <th>Shape</th>
           <th class="sortable">Buttons</th>
           <th class="sortable">Cost</th>
-          <th class="sortable">Time</th>
-          <th class="sortable">P/C</th>
-          <th class="sortable">P/C/A</th>
-          <th class="sortable">Value</th>
+          <th class="sortable">Time Penalty</th>
+          <th class="sortable">Current Value</th>
+          <th class="sortable">Value/Time</th>
+          <th class="sortable">Value/Time/Area</th>
           <th>Action</th>
         </tr>
       </thead>


### PR DESCRIPTION
## Summary
- Display current value, value per time, and value per time per area for each Patchwork piece
- Compute value metrics using cost, area, buttons, and current age
- Update documentation to describe new value calculations

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fa64abdac832889daaa6312d129a2