### PR TITLE
Refactor scoring and update metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ This repository contains a mobile-friendly web application for evaluating Patchw
 - Slider to set the current payday (1–9)
 - Draw shapes on a 5×5 grid and assign buttons, cost, and time penalty
 - Choose a color for each piece
-- Calculates current value, value per time penalty, and value per time penalty per area
+- Calculates gross score, net score, net score per time penalty, and net score per time penalty per area
 - Persistent piece library with edit and delete options
 - Purchased tiles move to a separate page and reappear after starting a new game
-- Purchased page displays purchase-time value and efficiency metrics with a mobile-friendly column selector
+- Purchased page displays purchase-time gross/net scores and efficiency metrics with a mobile-friendly column selector
 - Sortable table to order pieces by any stat
 - Server uses Express with Helmet and Pino for security and logging
 - Configurable host/port and production mode

--- a/public/index.html
+++ b/public/index.html
@@ -4,13 +4,13 @@
   Mini README:
   This HTML file renders the user interface for creating and evaluating Patchwork
   tiles. It includes controls for selecting the current payday, adding new pieces,
-  and viewing their calculated values.
+  and viewing their calculated scores.
 
   Structure:
   - Instructions header
   - Payday selection slider
   - Button to open the "Add Piece" form
-  - Table listing all available pieces with current value metrics (sortable by headers)
+  - Table listing all available pieces with current score metrics (sortable by headers)
   - Hidden modal-like form for drawing a new piece
 -->
 <!DOCTYPE html>
@@ -40,12 +40,10 @@
       <thead>
         <tr>
           <th>Shape</th>
-          <th class="sortable">Buttons</th>
-          <th class="sortable">Cost</th>
-          <th class="sortable">Time Penalty</th>
-          <th class="sortable">Current Value</th>
-          <th class="sortable">Value/Time</th>
-          <th class="sortable">Value/Time/Area</th>
+          <th class="sortable">Gross Score</th>
+          <th class="sortable">Net Score</th>
+          <th class="sortable">Net / Time Penalty</th>
+          <th class="sortable">Net / Time / Area</th>
           <th>Action</th>
         </tr>
       </thead>

--- a/public/purchased.html
+++ b/public/purchased.html
@@ -3,13 +3,14 @@
   ------------------------------
   Mini README:
   This HTML page lists tiles that have been purchased in the current game. It
-  shows the point value each tile had when bought along with efficiency metrics
-  and optionally lets players return a tile to the available pool.
+  shows the gross and net scores each tile had when bought along with
+  efficiency metrics and optionally lets players return a tile to the available
+  pool.
 
   Structure:
   - Instructions header with navigation back to the game
   - Optional dropdown to choose visible metric on small screens
-  - Table displaying purchase-time value metrics
+  - Table displaying purchase-time score metrics
   - Script handling rendering and return actions (action column hidden on small screens)
 -->
 <!DOCTYPE html>
@@ -23,25 +24,27 @@
 <body>
   <header>
     <h1>Purchased Tiles</h1>
-    <p class="instructions">These tiles have been bought this game. Values reflect remaining paydays at purchase. Use "Return" to undo a purchase.</p>
+    <p class="instructions">These tiles have been bought this game. Scores reflect remaining paydays at purchase. Use "Return" to undo a purchase.</p>
     <button id="backBtn">Back to Game</button>
   </header>
   <section>
     <div class="column-select">
       <label for="columnSelect">Show:</label>
       <select id="columnSelect">
-        <option value="value">Current Value</option>
-        <option value="valuePerTime">Value / Time</option>
-        <option value="valuePerTimePerArea">Value / Time / Area</option>
+        <option value="gross">Gross Score</option>
+        <option value="net">Net Score</option>
+        <option value="netPerTime">Net / Time Penalty</option>
+        <option value="netPerTimePerArea">Net / Time / Area</option>
       </select>
     </div>
     <table id="purchasedTable">
       <thead>
         <tr>
           <th>Shape</th>
-          <th class="value">Current Value</th>
-          <th class="valuePerTime">Value / Time</th>
-          <th class="valuePerTimePerArea">Value / Time / Area</th>
+          <th class="gross">Gross Score</th>
+          <th class="net">Net Score</th>
+          <th class="netPerTime">Net / Time Penalty</th>
+          <th class="netPerTimePerArea">Net / Time / Area</th>
           <th class="action">Action</th>
         </tr>
       </thead>

--- a/public/styles.css
+++ b/public/styles.css
@@ -121,12 +121,14 @@ header {
   }
 
   /* hide metric and action columns by default on narrow screens */
-  #purchasedTable th.value,
-  #purchasedTable th.valuePerTime,
-  #purchasedTable th.valuePerTimePerArea,
-  #purchasedTable td.value,
-  #purchasedTable td.valuePerTime,
-  #purchasedTable td.valuePerTimePerArea {
+  #purchasedTable th.gross,
+  #purchasedTable th.net,
+  #purchasedTable th.netPerTime,
+  #purchasedTable th.netPerTimePerArea,
+  #purchasedTable td.gross,
+  #purchasedTable td.net,
+  #purchasedTable td.netPerTime,
+  #purchasedTable td.netPerTimePerArea {
     display: none;
   }
 
@@ -136,12 +138,14 @@ header {
   }
 
   /* show selected metric column */
-  #purchasedTable.show-value th.value,
-  #purchasedTable.show-value td.value,
-  #purchasedTable.show-valuePerTime th.valuePerTime,
-  #purchasedTable.show-valuePerTime td.valuePerTime,
-  #purchasedTable.show-valuePerTimePerArea th.valuePerTimePerArea,
-  #purchasedTable.show-valuePerTimePerArea td.valuePerTimePerArea {
+  #purchasedTable.show-gross th.gross,
+  #purchasedTable.show-gross td.gross,
+  #purchasedTable.show-net th.net,
+  #purchasedTable.show-net td.net,
+  #purchasedTable.show-netPerTime th.netPerTime,
+  #purchasedTable.show-netPerTime td.netPerTime,
+  #purchasedTable.show-netPerTimePerArea th.netPerTimePerArea,
+  #purchasedTable.show-netPerTimePerArea td.netPerTimePerArea {
     display: table-cell;
   }
 }


### PR DESCRIPTION
## Summary
- replace old value formulas with gross and net scoring logic
- show gross, net, and efficiency metrics in piece and purchase tables
- document new scoring system in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fa8ecae5c832895f2805b7c3b460d