### PR TITLE
Add per-player purchase buttons and running score tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository contains a mobile-friendly web application for evaluating Patchw
 - Persistent piece library with edit and delete options
 - Purchased tiles move to a separate page and reappear after starting a new game
 - Purchased page displays purchase-time gross/net scores and efficiency metrics with a mobile-friendly column selector
+- Track yellow and green player purchases with dedicated buy buttons and running scores (162 minus purchased net values)
 - Sortable table to order pieces by any stat
 - Server uses Express with Helmet and Pino for security and logging
 - Configurable host/port and production mode

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
   - Instructions header
   - Payday selection slider
   - Button to open the "Add Piece" form
-  - Table listing all available pieces with current score metrics (sortable by headers)
+  - Table listing all available pieces with current score metrics (sortable by headers) and buy buttons for each player
   - Hidden modal-like form for drawing a new piece
 -->
 <!DOCTYPE html>
@@ -24,7 +24,7 @@
 <body>
   <header>
     <h1>Patchwork Tile Helper</h1>
-    <p class="instructions">Select the current payday, then add or buy tiles. Tap cells to draw shapes and choose a color. Use "New Game" to reset purchases. Tap column headers to sort pieces.</p>
+    <p class="instructions">Select the current payday, then add tiles. Use the yellow or green "Buy" buttons to record who purchased a tile. Tap cells to draw shapes and choose a color. Use "New Game" to reset purchases. Tap column headers to sort pieces.</p>
   </header>
   <section class="age-control">
     <label for="age">Current Payday: <span id="ageDisplay">1</span></label>

--- a/public/purchased.html
+++ b/public/purchased.html
@@ -9,8 +9,9 @@
 
   Structure:
   - Instructions header with navigation back to the game
+  - Running score display for yellow and green players
   - Optional dropdown to choose visible metric on small screens
-  - Table displaying purchase-time score metrics
+  - Table displaying purchase-time score metrics with a player column
   - Script handling rendering and return actions (action column hidden on small screens)
 -->
 <!DOCTYPE html>
@@ -24,9 +25,13 @@
 <body>
   <header>
     <h1>Purchased Tiles</h1>
-    <p class="instructions">These tiles have been bought this game. Scores reflect remaining paydays at purchase. Use "Return" to undo a purchase.</p>
+    <p class="instructions">These tiles have been bought this game. Scores reflect remaining paydays at purchase. Use "Return" to undo a purchase. Running scores show remaining points (162 minus the sum of purchased net values).</p>
     <button id="backBtn">Back to Game</button>
   </header>
+  <section id="scoreBoard">
+    <p>Yellow Player Score: <span id="yellowScore" class="yellow">162</span></p>
+    <p>Green Player Score: <span id="greenScore" class="green">162</span></p>
+  </section>
   <section>
     <div class="column-select">
       <label for="columnSelect">Show:</label>
@@ -41,6 +46,7 @@
       <thead>
         <tr>
           <th>Shape</th>
+          <th>Player</th>
           <th class="gross">Gross Score</th>
           <th class="net">Net Score</th>
           <th class="netPerTime">Net / Time Penalty</th>

--- a/public/styles.css
+++ b/public/styles.css
@@ -42,6 +42,32 @@ header {
   margin-bottom: 1rem;
 }
 
+.buy-yellow {
+  background: #ffeb3b;
+  border: 1px solid #c9b200;
+}
+
+.buy-green {
+  background: #4caf50;
+  color: #fff;
+  border: 1px solid #388e3c;
+}
+
+#scoreBoard {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+#scoreBoard .yellow {
+  color: #fdd835;
+  font-weight: bold;
+}
+
+#scoreBoard .green {
+  color: #4caf50;
+  font-weight: bold;
+}
+
 #piecesTable {
   width: 100%;
   border-collapse: collapse;


### PR DESCRIPTION
## Summary
- Add yellow and green buy buttons for each piece and store player info
- Display player column and running score on purchased tiles page (162 minus net values)
- Style new buttons and scoreboard; document feature in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fac47be108328a89ee497521f0063