### PR TITLE
Fix remaining payday calculation for piece scoring

### DIFF
--- a/public/patchwork_client.js
+++ b/public/patchwork_client.js
@@ -172,7 +172,10 @@ function renderShape(shape, color = '#4caf50') {
 // Calculate current score metrics for a piece at a given age
 function computeScoreStats(piece, age = currentAge) {
   const area = piece.shape.length;
-  const remainingPaydays = AGE_COUNT - age;
+  // age slider names the *next* payday to be passed, so when age is 1
+  // there are still all 9 paydays remaining. Use AGE_COUNT - age + 1 as the
+  // base to reflect the correct number of remaining paydays.
+  const remainingPaydays = AGE_COUNT - age + 1;
   const grossScore = area * 2 + piece.buttons * remainingPaydays;
   const netScore = grossScore - piece.cost;
   const netScorePerTime = piece.time ? netScore / piece.time : netScore;

--- a/public/purchased_client.js
+++ b/public/purchased_client.js
@@ -63,7 +63,9 @@ function savePurchased() {
 
 function computeMetrics(piece) {
   const area = piece.shape.length;
-  const remainingPaydays = AGE_COUNT - piece.purchaseAge;
+  // purchaseAge stores the next payday to be passed at time of buy.
+  // To capture all remaining paydays, subtract from AGE_COUNT and add 1.
+  const remainingPaydays = AGE_COUNT - piece.purchaseAge + 1;
   const grossScore = area * 2 + piece.buttons * remainingPaydays;
   const netScore = grossScore - piece.cost;
   const netScorePerTime = piece.time ? netScore / piece.time : netScore;


### PR DESCRIPTION
## Summary
- Correct remaining payday base so gross score uses all upcoming paydays
- Update purchased tile metrics to compute gross score with revised base

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fae30063c8328b97cdacb579c6f51