### PR TITLE
Fix scoring computation for purchased tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository contains a mobile-friendly web application for evaluating Patchw
 - Persistent piece library with edit and delete options
 - Purchased tiles move to a separate page and reappear after starting a new game
 - Purchased page displays purchase-time gross/net scores and efficiency metrics with a mobile-friendly column selector
-- Track yellow and green player purchases with dedicated buy buttons and running scores (162 minus purchased net values)
+- Track yellow and green player purchases with dedicated buy buttons and running scores (sum of purchased net values minus 162)
 - Sortable table to order pieces by any stat
 - Server uses Express with Helmet and Pino for security and logging
 - Configurable host/port and production mode

--- a/public/purchased.html
+++ b/public/purchased.html
@@ -5,7 +5,8 @@
   This HTML page lists tiles that have been purchased in the current game. It
   shows the gross and net scores each tile had when bought along with
   efficiency metrics and optionally lets players return a tile to the available
-  pool.
+  pool. Running scores are computed by summing purchased net values and
+  subtracting 162 to produce each player's final score.
 
   Structure:
   - Instructions header with navigation back to the game
@@ -25,12 +26,12 @@
 <body>
   <header>
     <h1>Purchased Tiles</h1>
-    <p class="instructions">These tiles have been bought this game. Scores reflect remaining paydays at purchase. Use "Return" to undo a purchase. Running scores show remaining points (162 minus the sum of purchased net values).</p>
+    <p class="instructions">These tiles have been bought this game. Scores reflect remaining paydays at purchase. Use "Return" to undo a purchase. Running scores show final points (sum of purchased net values minus 162).</p>
     <button id="backBtn">Back to Game</button>
   </header>
   <section id="scoreBoard">
-    <p>Yellow Player Score: <span id="yellowScore" class="yellow">162</span></p>
-    <p>Green Player Score: <span id="greenScore" class="green">162</span></p>
+    <p>Yellow Player Score: <span id="yellowScore" class="yellow">-162</span></p>
+    <p>Green Player Score: <span id="greenScore" class="green">-162</span></p>
   </section>
   <section>
     <div class="column-select">

--- a/public/purchased_client.js
+++ b/public/purchased_client.js
@@ -7,8 +7,8 @@
  displays each tile's gross and net scores at the moment of purchase along with
  efficiency metrics so scores remain historically accurate. Purchases record
  which player (yellow or green) bought the tile and a running score is
- maintained assuming each player starts with 162 points minus the sum of their
- purchased net values.
+ maintained by summing purchased net values and subtracting 162 to
+ calculate each player's final score.
 
  Structure:
  - Load purchased tiles from localStorage
@@ -138,8 +138,8 @@ function updateScores() {
   const greenTotal = purchasedPieces
     .filter(p => p.player === 'green')
     .reduce((sum, p) => sum + (p.purchaseNet || 0), 0);
-  yellowScoreEl.textContent = 162 - yellowTotal;
-  greenScoreEl.textContent = 162 - greenTotal;
+  yellowScoreEl.textContent = yellowTotal - 162;
+  greenScoreEl.textContent = greenTotal - 162;
 }
 
 backBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Correct running score formula to subtract 162 from sum of net values
- Update purchased tiles page and documentation to reflect final score rule

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689faf705c6c83289876c146c3b25e12