### PR TITLE
Improve mobile touch support and grid drawing

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -31,9 +31,9 @@
     <input type="range" id="age" min="1" max="9" value="1" />
   </section>
   <section class="piece-actions">
-    <button id="addPieceBtn">Add Piece</button>
-    <button id="newGameBtn">New Game</button>
-    <button id="viewPurchasedBtn">View Purchased Tiles</button>
+    <button id="addPieceBtn" type="button">Add Piece</button>
+    <button id="newGameBtn" type="button">New Game</button>
+    <button id="viewPurchasedBtn" type="button">View Purchased Tiles</button>
   </section>
   <section>
     <table id="piecesTable">
@@ -60,8 +60,8 @@
       <label>Color: <input type="color" id="colorInput" value="#4caf50" /></label>
     </div>
     <div class="form-actions">
-      <button id="savePiece">Save</button>
-      <button id="cancelPiece">Cancel</button>
+      <button id="savePiece" type="button">Save</button>
+      <button id="cancelPiece" type="button">Cancel</button>
     </div>
   </section>
   <script src="patchwork_client.js"></script>

--- a/public/patchwork_client.js
+++ b/public/patchwork_client.js
@@ -63,6 +63,10 @@ const colorInput = document.getElementById('colorInput');
 const savePieceBtn = document.getElementById('savePiece');
 const cancelPieceBtn = document.getElementById('cancelPiece');
 
+// Use a pointer-friendly event for taps/clicks so mobile devices respond
+// immediately without relying solely on the delayed "click" synthesis.
+const tapEvent = window.PointerEvent ? 'pointerup' : 'click';
+
 // initialize age slider display
 ageInput.value = currentAge;
 ageDisplay.textContent = currentAge;
@@ -96,7 +100,7 @@ function updateSortIndicators() {
 for (let index = 0; index < headerCells.length; index += 1) {
   const th = headerCells[index];
   if (!sortableColumns[index]) continue; // skip non-sortable headers
-  th.addEventListener('click', () => {
+  th.addEventListener(tapEvent, () => {
     const key = sortableColumns[index];
     if (sortState.key === key) {
       sortState.asc = !sortState.asc;
@@ -123,10 +127,18 @@ function createGrid() {
   grid.style.setProperty('--active-color', colorInput.value);
   for (let i = 0; i < 25; i++) {
     const cell = document.createElement('div');
-    const toggle = () => cell.classList.toggle('active');
-    // Support both mouse and touch interactions for mobile friendliness
-    cell.addEventListener('click', toggle);
-    cell.addEventListener('touchstart', toggle);
+    const toggle = (ev) => {
+      ev.preventDefault();
+      cell.classList.toggle('active');
+    };
+    // Use pointer events when available; fall back to click+touch with proper
+    // prevention so taps on mobile devices only toggle once.
+    if (window.PointerEvent) {
+      cell.addEventListener('pointerdown', toggle);
+    } else {
+      cell.addEventListener('touchstart', toggle, { passive: false });
+      cell.addEventListener('click', toggle);
+    }
     grid.appendChild(cell);
   }
 }
@@ -254,20 +266,23 @@ function refreshTable() {
 
     const actionTd = document.createElement('td');
     const yellowBtn = document.createElement('button');
+    yellowBtn.type = 'button';
     yellowBtn.textContent = 'Buy Yellow';
     yellowBtn.classList.add('buy-yellow');
-    yellowBtn.addEventListener('click', () => purchasePiece(piece, 'yellow'));
+    yellowBtn.addEventListener(tapEvent, () => purchasePiece(piece, 'yellow'));
     actionTd.appendChild(yellowBtn);
 
     const greenBtn = document.createElement('button');
+    greenBtn.type = 'button';
     greenBtn.textContent = 'Buy Green';
     greenBtn.classList.add('buy-green');
-    greenBtn.addEventListener('click', () => purchasePiece(piece, 'green'));
+    greenBtn.addEventListener(tapEvent, () => purchasePiece(piece, 'green'));
     actionTd.appendChild(greenBtn);
 
     const editBtn = document.createElement('button');
+    editBtn.type = 'button';
     editBtn.textContent = 'Edit';
-    editBtn.addEventListener('click', () => {
+    editBtn.addEventListener(tapEvent, () => {
       editingPieceId = piece.id;
       buttonsInput.value = piece.buttons;
       costInput.value = piece.cost;
@@ -279,8 +294,9 @@ function refreshTable() {
     actionTd.appendChild(editBtn);
 
     const deleteBtn = document.createElement('button');
+    deleteBtn.type = 'button';
     deleteBtn.textContent = 'Delete';
-    deleteBtn.addEventListener('click', () => {
+    deleteBtn.addEventListener(tapEvent, () => {
       console.debug('Deleting piece', piece.id);
       pieceLibrary = pieceLibrary.filter(p => p.id !== piece.id);
       availablePieces = availablePieces.filter(p => p.id !== piece.id);
@@ -303,7 +319,7 @@ ageInput.addEventListener('input', () => {
   refreshTable();
 });
 
-addPieceBtn.addEventListener('click', () => {
+addPieceBtn.addEventListener(tapEvent, () => {
   editingPieceId = null;
   pieceForm.classList.remove('hidden');
   colorInput.value = '#4caf50';
@@ -313,7 +329,7 @@ addPieceBtn.addEventListener('click', () => {
   timeInput.value = 0;
 });
 
-savePieceBtn.addEventListener('click', () => {
+savePieceBtn.addEventListener(tapEvent, () => {
   const shape = getGridShape();
   if (shape.length === 0) {
     alert('Please draw at least one square.');
@@ -351,19 +367,19 @@ savePieceBtn.addEventListener('click', () => {
   refreshTable();
 });
 
-cancelPieceBtn.addEventListener('click', () => {
+cancelPieceBtn.addEventListener(tapEvent, () => {
   pieceForm.classList.add('hidden');
   editingPieceId = null;
 });
 
-newGameBtn.addEventListener('click', () => {
+newGameBtn.addEventListener(tapEvent, () => {
   purchasedPieces = [];
   savePurchased();
   availablePieces = pieceLibrary.slice();
   refreshTable();
 });
 
-viewPurchasedBtn.addEventListener('click', () => {
+viewPurchasedBtn.addEventListener(tapEvent, () => {
   window.location.href = 'purchased.html';
 });
 

--- a/public/purchased.html
+++ b/public/purchased.html
@@ -27,7 +27,7 @@
   <header>
     <h1>Purchased Tiles</h1>
     <p class="instructions">These tiles have been bought this game. Scores reflect remaining paydays at purchase. Use "Return" to undo a purchase. Running scores show final points (sum of purchased net values minus 162).</p>
-    <button id="backBtn">Back to Game</button>
+    <button id="backBtn" type="button">Back to Game</button>
   </header>
   <section id="scoreBoard">
     <p>Yellow Player Score: <span id="yellowScore" class="yellow">-162</span></p>

--- a/public/purchased_client.js
+++ b/public/purchased_client.js
@@ -44,6 +44,9 @@ const columnSelect = document.getElementById('columnSelect');
 const yellowScoreEl = document.getElementById('yellowScore');
 const greenScoreEl = document.getElementById('greenScore');
 
+// Normalise click/tap interactions for mobile devices.
+const tapEvent = window.PointerEvent ? 'pointerup' : 'click';
+
 function renderShape(shape, color = '#4caf50') {
   const container = document.createElement('div');
   container.classList.add('grid');
@@ -116,8 +119,9 @@ function refreshTable() {
     const actionTd = document.createElement('td');
     actionTd.classList.add('action');
     const returnBtn = document.createElement('button');
+    returnBtn.type = 'button';
     returnBtn.textContent = 'Return';
-    returnBtn.addEventListener('click', () => {
+    returnBtn.addEventListener(tapEvent, () => {
       purchasedPieces = purchasedPieces.filter(p => p.id !== piece.id);
       savePurchased();
       refreshTable();
@@ -142,7 +146,7 @@ function updateScores() {
   greenScoreEl.textContent = greenTotal - 162;
 }
 
-backBtn.addEventListener('click', () => {
+backBtn.addEventListener(tapEvent, () => {
   window.location.href = 'index.html';
 });
 


### PR DESCRIPTION
## Summary
- ensure buttons trigger on touch devices by using pointer-aware `tapEvent`
- fix grid drawing on mobile with pointer events and prevent duplicate toggles
- add explicit `type="button"` to avoid unintended form submits

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fb302a15483289e5af6df262ca461