### PR TITLE
fix: enable drawing new piece on mobile

### DIFF
--- a/public/patchwork_client.js
+++ b/public/patchwork_client.js
@@ -131,12 +131,15 @@ function createGrid() {
       ev.preventDefault();
       cell.classList.toggle('active');
     };
-    // Use pointer events when available; fall back to click+touch with proper
-    // prevention so taps on mobile devices only toggle once.
+    // Use pointer events when available. Otherwise choose touch or click
+    // explicitly so that taps on mobile devices do not trigger both touch and
+    // synthetic click events (which previously cancelled each other out and
+    // made the grid seem non‑functional on phones).
     if (window.PointerEvent) {
       cell.addEventListener('pointerdown', toggle);
-    } else {
+    } else if ('ontouchstart' in window) {
       cell.addEventListener('touchstart', toggle, { passive: false });
+    } else {
       cell.addEventListener('click', toggle);
     }
     grid.appendChild(cell);


### PR DESCRIPTION
## Summary
- prevent touch and click events from cancelling each other so the draw grid works on mobile

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fb5267f648328a9dbe6e89a67d24c