### PR TITLE
Document server-side persistence for shared Patchwork state

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ This repository contains a mobile-friendly web application for evaluating Patchw
 - Server uses Express with Helmet and Pino for security and logging
 - Configurable host/port and production mode
 
+## Server-side Persistence
+State is shared across all clients and stored on the server.
+
+- The server writes `data/patchwork_state.json`, creating it on first run.
+- `GET /api/state` returns the current `nextId`, `pieceLibrary` and
+  `purchasedPieces`.
+- `POST /api/state` accepts a JSON body with the same fields and persists it
+  to disk.
+
+Deleting the JSON file resets the application to a clean slate on the next
+server start.
+
 ## Setup
 ### Linux / Raspberry Pi
 ```bash


### PR DESCRIPTION
## Summary
- Document shared JSON persistence and `/api/state` endpoint in the README.
- Server already persists piece library and purchased tiles to `data/patchwork_state.json` and exposes REST API.
- Clients synchronise game state via `/api/state` to share library and purchases across browsers.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0478df8388328949bbfe04ef1411a