### PR TITLE
Fix asset loading when accessing app via network IP

### DIFF
--- a/patchwork_server.js
+++ b/patchwork_server.js
@@ -8,7 +8,9 @@
  *
  * Structure:
  * - Loads environment variables and command line arguments for configuration.
- * - Sets up Express with Helmet for basic security headers and Pino for logging.
+ * - Sets up Express with Helmet for basic security headers and a permissive
+ *   cross-origin resource policy so CSS/JS load when accessed via IP, plus Pino
+ *   for logging.
  * - Maintains a shared piece/purchase state on disk for all clients.
  * - Exposes `/api/state` for clients to read and update this state.
  * - Serves static files from the "public" directory.
@@ -79,7 +81,9 @@ for (let i = 0; i < args.length; i += 1) {
 logger.debug(`Resolved configuration host=${host} port=${port}`);
 
 const app = express();
-app.use(helmet());
+// Allow assets to load when the site is accessed via its network IP by
+// permitting cross-origin resource sharing for static files.
+app.use(helmet({ crossOriginResourcePolicy: { policy: 'cross-origin' } }));
 app.use(pinoHttp({ logger }));
 app.use(express.json({ limit: '100kb' }));
 

--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,7 @@
   - Button to open the "Add Piece" form
   - Table listing all available pieces with current score metrics (sortable by headers) and buy buttons for each player
   - Hidden modal-like form for drawing a new piece
+  - Asset links use absolute paths so the UI works when accessed via network IP
 -->
 <!DOCTYPE html>
 <html lang="en">
@@ -19,7 +20,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Patchwork Tile Helper</title>
-  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="/styles.css" />
 </head>
 <body>
   <header>
@@ -64,6 +65,6 @@
       <button id="cancelPiece" type="button">Cancel</button>
     </div>
   </section>
-  <script src="patchwork_client.js"></script>
+  <script src="/patchwork_client.js"></script>
 </body>
 </html>

--- a/public/patchwork_client.js
+++ b/public/patchwork_client.js
@@ -19,6 +19,7 @@
  - Event listeners for CRUD actions and game flow
   - Column sorting for the pieces table
   - Per-player purchase buttons (yellow and green)
+ - Navigation uses absolute paths for compatibility when accessed via IP
 */
 
 const AGE_COUNT = 9; // number of paydays/ages in the game
@@ -406,7 +407,7 @@ newGameBtn.addEventListener(tapEvent, () => {
 });
 
 viewPurchasedBtn.addEventListener(tapEvent, () => {
-  window.location.href = 'purchased.html';
+  window.location.href = '/purchased.html';
 });
 
 // initialize application once the server state has loaded

--- a/public/purchased.html
+++ b/public/purchased.html
@@ -14,6 +14,7 @@
   - Optional dropdown to choose visible metric on small screens
   - Table displaying purchase-time score metrics with a player column
   - Script handling rendering and return actions (action column hidden on small screens)
+  - Asset links use absolute paths for reliability over network IPs
 -->
 <!DOCTYPE html>
 <html lang="en">
@@ -21,7 +22,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Purchased Tiles</title>
-  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="/styles.css" />
 </head>
 <body>
   <header>
@@ -58,6 +59,6 @@
       <tbody></tbody>
     </table>
   </section>
-  <script src="purchased_client.js"></script>
+  <script src="/purchased_client.js"></script>
 </body>
 </html>

--- a/public/purchased_client.js
+++ b/public/purchased_client.js
@@ -14,10 +14,11 @@
  Structure:
  - Load purchased tiles from the server
  - Display stored purchase-time score metrics
- - Render table with shapes, metrics and a return button
+- Render table with shapes, metrics and a return button
   - Show running scores for yellow and green players
- - Dropdown to choose which metric column is visible on small screens
- - Navigation back to the main game interface
+- Dropdown to choose which metric column is visible on small screens
+- Navigation back to the main game interface
+ - Navigation uses absolute paths for compatibility when served via IP
 */
 
 const AGE_COUNT = 9; // total number of paydays/ages
@@ -172,7 +173,7 @@ function updateScores() {
 }
 
 backBtn.addEventListener(tapEvent, () => {
-  window.location.href = 'index.html';
+  window.location.href = '/';
 });
 
 columnSelect.addEventListener('change', () => {


### PR DESCRIPTION
## Summary
- allow helmet to serve static assets cross-origin so CSS/JS load when using an IP address
- use absolute paths for client scripts and styles
- make navigation links absolute to ensure buttons work over the network

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0579824108328a0a42b1276edd463