### PR TITLE
Use sliders for piece attributes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,7 @@
   - Button to open the "Add Piece" form
   - Table listing all available pieces with current score metrics (sortable by headers) and buy buttons for each player
   - Hidden modal-like form for drawing a new piece
+  - Slider controls for buttons, cost and movement when adding a piece
   - Asset links use absolute paths so the UI works when accessed via network IP
 -->
 <!DOCTYPE html>
@@ -25,7 +26,7 @@
 <body>
   <header>
     <h1>Patchwork Tile Helper</h1>
-    <p class="instructions">Select the current payday, then add tiles. Use the yellow or green "Buy" buttons to record who purchased a tile. Tap cells to draw shapes and choose a color. Use "New Game" to reset purchases. Tap column headers to sort pieces.</p>
+    <p class="instructions">Select the current payday, then add tiles. Use the sliders to set buttons (0–3), cost (0–10) and movement (0–6). Use the yellow or green "Buy" buttons to record who purchased a tile. Tap cells to draw shapes and choose a color. Use "New Game" to reset purchases. Tap column headers to sort pieces.</p>
   </header>
   <section class="age-control">
     <label for="age">Current Payday: <span id="ageDisplay">1</span></label>
@@ -55,9 +56,18 @@
     <h2>New Piece</h2>
     <div id="grid" class="grid"></div>
     <div class="form-fields">
-      <label>Buttons: <input type="number" id="buttonsInput" min="0" value="0" /></label>
-      <label>Cost: <input type="number" id="costInput" min="0" value="0" /></label>
-      <label>Time Penalty: <input type="number" id="timeInput" min="0" value="0" /></label>
+      <label>Buttons:
+        <input type="range" id="buttonsInput" min="0" max="3" step="1" value="0" />
+        <span id="buttonsDisplay">0</span>
+      </label>
+      <label>Cost:
+        <input type="range" id="costInput" min="0" max="10" step="1" value="0" />
+        <span id="costDisplay">0</span>
+      </label>
+      <label>Movement:
+        <input type="range" id="movementInput" min="0" max="6" step="1" value="0" />
+        <span id="movementDisplay">0</span>
+      </label>
       <label>Color: <input type="color" id="colorInput" value="#4caf50" /></label>
     </div>
     <div class="form-actions">

--- a/public/patchwork_client.js
+++ b/public/patchwork_client.js
@@ -19,7 +19,8 @@
  - Event listeners for CRUD actions and game flow
   - Column sorting for the pieces table
   - Per-player purchase buttons (yellow and green)
- - Navigation uses absolute paths for compatibility when accessed via IP
+  - Navigation uses absolute paths for compatibility when accessed via IP
+ - Slider controls for buttons, cost, and movement values when creating pieces
 */
 
 const AGE_COUNT = 9; // number of paydays/ages in the game
@@ -91,8 +92,11 @@ const pieceForm = document.getElementById('pieceForm');
 const grid = document.getElementById('grid');
 const buttonsInput = document.getElementById('buttonsInput');
 const costInput = document.getElementById('costInput');
-const timeInput = document.getElementById('timeInput');
+const movementInput = document.getElementById('movementInput');
 const colorInput = document.getElementById('colorInput');
+const buttonsDisplay = document.getElementById('buttonsDisplay');
+const costDisplay = document.getElementById('costDisplay');
+const movementDisplay = document.getElementById('movementDisplay');
 const savePieceBtn = document.getElementById('savePiece');
 const cancelPieceBtn = document.getElementById('cancelPiece');
 
@@ -103,6 +107,19 @@ const tapEvent = window.PointerEvent ? 'pointerup' : 'click';
 // initialize age slider display
 ageInput.value = currentAge;
 ageDisplay.textContent = currentAge;
+buttonsDisplay.textContent = buttonsInput.value;
+costDisplay.textContent = costInput.value;
+movementDisplay.textContent = movementInput.value;
+
+buttonsInput.addEventListener('input', () => {
+  buttonsDisplay.textContent = buttonsInput.value;
+});
+costInput.addEventListener('input', () => {
+  costDisplay.textContent = costInput.value;
+});
+movementInput.addEventListener('input', () => {
+  movementDisplay.textContent = movementInput.value;
+});
 
 // Track which column is sorted and direction
 let sortState = { key: null, asc: true };
@@ -313,8 +330,11 @@ function refreshTable() {
       editingPieceId = piece.id;
       buttonsInput.value = piece.buttons;
       costInput.value = piece.cost;
-      timeInput.value = piece.time;
+      movementInput.value = piece.time;
       colorInput.value = piece.color || '#4caf50';
+      buttonsDisplay.textContent = buttonsInput.value;
+      costDisplay.textContent = costInput.value;
+      movementDisplay.textContent = movementInput.value;
       loadShapeIntoGrid(piece.shape);
       pieceForm.classList.remove('hidden');
     });
@@ -353,7 +373,10 @@ addPieceBtn.addEventListener(tapEvent, () => {
   createGrid();
   buttonsInput.value = 0;
   costInput.value = 0;
-  timeInput.value = 0;
+  movementInput.value = 0;
+  buttonsDisplay.textContent = '0';
+  costDisplay.textContent = '0';
+  movementDisplay.textContent = '0';
 });
 
 savePieceBtn.addEventListener(tapEvent, () => {
@@ -368,7 +391,7 @@ savePieceBtn.addEventListener(tapEvent, () => {
       piece.shape = shape;
       piece.buttons = parseInt(buttonsInput.value, 10) || 0;
       piece.cost = parseInt(costInput.value, 10) || 0;
-      piece.time = parseInt(timeInput.value, 10) || 0;
+      piece.time = parseInt(movementInput.value, 10) || 0;
       piece.color = colorInput.value;
     }
     const avail = availablePieces.find(p => p.id === editingPieceId);
@@ -382,7 +405,7 @@ savePieceBtn.addEventListener(tapEvent, () => {
       shape,
       buttons: parseInt(buttonsInput.value, 10) || 0,
       cost: parseInt(costInput.value, 10) || 0,
-      time: parseInt(timeInput.value, 10) || 0,
+      time: parseInt(movementInput.value, 10) || 0,
       color: colorInput.value
     };
     console.debug('Adding piece', piece);


### PR DESCRIPTION
## Summary
- Replace numeric fields with sliders for buttons (0-3), cost (0-10), and movement (0-6)
- Display current slider values and sync with form edits
- Update instructions to mention new sliders

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a05e01664c8328990a9ba22214b451