### PR TITLE
feat: track buttons and bonus on purchased page

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repository contains a mobile-friendly web application for evaluating Patchw
 - Purchased tiles move to a separate page and reappear after starting a new game
 - Purchased page displays purchase-time gross/net scores and efficiency metrics with a mobile-friendly column selector
 - Track yellow and green player purchases with dedicated buy buttons and running scores (sum of purchased net values minus 162)
+- Purchased page records buttons on hand and assigns the 7-point bonus, automatically adding these to running scores
 - Sortable table to order pieces by any stat
 - Shared state stored server-side so multiple clients see the same tiles and purchases
 - Server uses Express with Helmet and Pino for security and logging
@@ -21,10 +22,10 @@ This repository contains a mobile-friendly web application for evaluating Patchw
 State is shared across all clients and stored on the server.
 
 - The server writes `data/patchwork_state.json`, creating it on first run.
-- `GET /api/state` returns the current `nextId`, `pieceLibrary` and
-  `purchasedPieces`.
-- `POST /api/state` accepts a JSON body with the same fields and persists it
-  to disk.
+- `GET /api/state` returns the current `nextId`, `pieceLibrary`,
+  `purchasedPieces`, `yellowButtons`, `greenButtons` and `bonusWinner`.
+- `POST /api/state` accepts a JSON body with the same fields and persists it to
+  disk.
 
 Deleting the JSON file resets the application to a clean slate on the next
 server start.

--- a/public/purchased.html
+++ b/public/purchased.html
@@ -5,12 +5,15 @@
   This HTML page lists tiles that have been purchased in the current game. It
   shows the gross and net scores each tile had when bought along with
   efficiency metrics and optionally lets players return a tile to the available
-  pool. Running scores are computed by summing purchased net values and
-  subtracting 162 to produce each player's final score.
+  pool. Players can also record buttons on hand for yellow and green and
+  choose who receives the 7-point bonus. Running scores combine purchased net
+  values, buttons on hand and any bonus, then subtract 162 to produce each
+  player's final score.
 
   Structure:
   - Instructions header with navigation back to the game
-  - Running score display for yellow and green players
+  - Running score display for yellow and green players with inputs for
+    buttons on hand and the 7-point bonus
   - Optional dropdown to choose visible metric on small screens
   - Table displaying purchase-time score metrics with a player column
   - Script handling rendering and return actions (action column hidden on small screens)
@@ -27,12 +30,22 @@
 <body>
   <header>
     <h1>Purchased Tiles</h1>
-    <p class="instructions">These tiles have been bought this game. Scores reflect remaining paydays at purchase. Use "Return" to undo a purchase. Running scores show final points (sum of purchased net values minus 162).</p>
+    <p class="instructions">These tiles have been bought this game. Scores reflect remaining paydays at purchase. Use "Return" to undo a purchase. Record buttons on hand and the 7-point bonus below; running scores update automatically.</p>
     <button id="backBtn" type="button">Back to Game</button>
   </header>
   <section id="scoreBoard">
     <p>Yellow Player Score: <span id="yellowScore" class="yellow">-162</span></p>
+    <label for="yellowButtons">Yellow Buttons on Hand:</label>
+    <input type="number" id="yellowButtons" min="0" value="0" />
     <p>Green Player Score: <span id="greenScore" class="green">-162</span></p>
+    <label for="greenButtons">Green Buttons on Hand:</label>
+    <input type="number" id="greenButtons" min="0" value="0" />
+    <fieldset>
+      <legend>7-Point Bonus</legend>
+      <label><input type="radio" name="bonus" id="bonusNone" value="none" checked />None</label>
+      <label><input type="radio" name="bonus" id="bonusYellow" value="yellow" />Yellow</label>
+      <label><input type="radio" name="bonus" id="bonusGreen" value="green" />Green</label>
+    </fieldset>
   </section>
   <section>
     <div class="column-select">


### PR DESCRIPTION
## Summary
- allow entering buttons on hand for each player
- support selecting who receives the 7-point bonus
- include buttons and bonus in saved state and final scores

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a065aaaacc83289880d6d4315f4ac9