### PR TITLE
feat: allow piece library export and import

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository contains a mobile-friendly web application for evaluating Patchw
 - Choose a color for each piece
 - Calculates gross score, net score, net score per time penalty, and net score per time penalty per area
 - Persistent piece library with edit and delete options
+- Export and import the piece library as JSON files
 - Purchased tiles move to a separate page and reappear after starting a new game
 - Purchased page displays purchase-time gross/net scores and efficiency metrics with a mobile-friendly column selector
 - Track yellow and green player purchases with dedicated buy buttons and running scores (sum of purchased net values minus 162)
@@ -55,6 +56,7 @@ npm start --port 8080 --host 0.0.0.0
 PORT=5000 HOST=0.0.0.0 npm start
 ```
 Then open `http://HOST:PORT` in a browser from any device on the network.
+Use the on-screen **Export Library** and **Import Library** buttons to back up or restore pieces.
 
 ## Debugging
 - Server logs are written to stdout using Pino.

--- a/public/index.html
+++ b/public/index.html
@@ -9,10 +9,11 @@
   Structure:
   - Instructions header
   - Payday selection slider
-  - Button to open the "Add Piece" form
-  - Table listing all available pieces with current score metrics (sortable by headers) and buy buttons for each player
-  - Hidden modal-like form for drawing a new piece
-  - Slider controls for buttons, cost and movement when adding a piece
+    - Button to open the "Add Piece" form
+    - Buttons to export or import the piece library
+    - Table listing all available pieces with current score metrics (sortable by headers) and buy buttons for each player
+    - Hidden modal-like form for drawing a new piece
+    - Slider controls for buttons, cost and movement when adding a piece
   - Asset links use absolute paths so the UI works when accessed via network IP
 -->
 <!DOCTYPE html>
@@ -26,17 +27,20 @@
 <body>
   <header>
     <h1>Patchwork Tile Helper</h1>
-    <p class="instructions">Select the current payday, then add tiles. Use the sliders to set buttons (0–3), cost (0–10) and movement (0–6). Use the yellow or green "Buy" buttons to record who purchased a tile. Tap cells to draw shapes and choose a color. Use "New Game" to reset purchases. Tap column headers to sort pieces.</p>
+      <p class="instructions">Select the current payday, then add tiles. Use the sliders to set buttons (0–3), cost (0–10) and movement (0–6). Use the yellow or green "Buy" buttons to record who purchased a tile. Tap cells to draw shapes and choose a color. Use "Export Library" to download your pieces and "Import Library" to load a saved file. Use "New Game" to reset purchases. Tap column headers to sort pieces.</p>
   </header>
   <section class="age-control">
     <label for="age">Current Payday: <span id="ageDisplay">1</span></label>
     <input type="range" id="age" min="1" max="9" value="1" />
   </section>
-  <section class="piece-actions">
-    <button id="addPieceBtn" type="button">Add Piece</button>
-    <button id="newGameBtn" type="button">New Game</button>
-    <button id="viewPurchasedBtn" type="button">View Purchased Tiles</button>
-  </section>
+    <section class="piece-actions">
+      <button id="addPieceBtn" type="button">Add Piece</button>
+      <button id="newGameBtn" type="button">New Game</button>
+      <button id="viewPurchasedBtn" type="button">View Purchased Tiles</button>
+      <button id="exportBtn" type="button">Export Library</button>
+      <button id="importBtn" type="button">Import Library</button>
+      <input id="importInput" type="file" accept="application/json" class="hidden" />
+    </section>
   <section>
     <table id="piecesTable">
       <thead>


### PR DESCRIPTION
## Summary
- add UI buttons to export or import the Patchwork piece library
- implement client-side JSON export/import logic with basic validation
- document library backup/restore in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a06c72d2b88328b54631083cc00d0a